### PR TITLE
game component scoring

### DIFF
--- a/example.sh
+++ b/example.sh
@@ -13,6 +13,8 @@ dfx canister call metascore register "(principal \"$gameID\")"
 dfx canister call metascore getOverallRanking "(principal \"$gameID\")"
 dfx canister call metascore getRanking "(principal \"$gameID\", $playerS)"
 dfx canister call metascore getPercentile "(principal \"$gameID\", $playerS)"
+dfx canister call metascore getGameScoreComponent "(principal \"$gameID\", $playerP)"
+dfx canister call metascore getGameScoreComponent "(principal \"$gameID\", $playerS)"
 
 dfx canister call metascore cron > /dev/null
 
@@ -26,6 +28,8 @@ dfx stop
 # (vec { principal "2ibo7-dia"; principal "uuc56-gyb" })
 # (opt (2 : nat))
 # (opt (0.5 : float64))
+# (opt (1_000_000_000_000 : nat))
+# (opt (750_000_000_000 : nat))
 #
 # [Canister rrkah-fqaaa-aaaaa-aaaaq-cai] Getting scores...
 # [Canister rwlgt-iiaaa-aaaaa-aaaaa-cai] Returning scores...


### PR DESCRIPTION
An attempt at the normalized scoring equation for each game. Intended to incentivize playing ALL of the games, and fights for the podium. Players can get a possible 1 trillion points from each game. The big number will provide enough resolution that ties shouldn't happen often, and trillions sounds cool 😎