### PR TITLE
use principals instead of text for wallet addresses

### DIFF
--- a/example/main.mo
+++ b/example/main.mo
@@ -9,8 +9,8 @@ shared ({caller = owner}) actor class Game() : async MPublic.GameInterface {
     public query func metascoreScores() : async [MPublic.Score] {
         Debug.print("Returning scores...");
         [
-            (#plug("playerPlug"), 10),
-            (#stoic("playerStoic"), 8),
+            (#plug(Principal.fromText("ztlax-3lufm-ahpvx-36scg-7b4lf-m34dn-md7or-ltgjf-nhq4k-qqffn-oqe")), 10),
+            (#stoic(Principal.fromText("k4ltb-urk4m-kdfc4-a2sib-br5ub-gcnep-tkxt2-2oqqa-ldzj2-zvmyw-gqe")), 8),
         ];
     };
 

--- a/metascore/Player.mo
+++ b/metascore/Player.mo
@@ -1,29 +1,29 @@
 import Bool "mo:base/Bool";
 import Hash "mo:base/Hash";
-import Text "mo:base/Text";
+import Principal "mo:base/Principal";
 
 import MPublic "../src/Metascore";
 
 module {
     public let equal = func (a : MPublic.Player, b : MPublic.Player) : Bool {
         switch (a, b) {
-            case (#stoic(a), #stoic(b)) { Text.equal(a, b); };
-            case (#plug(a) , #plug(b) ) { Text.equal(a, b); };
+            case (#stoic(a), #stoic(b)) { Principal.equal(a, b); };
+            case (#plug(a) , #plug(b) ) { Principal.equal(a, b); };
             case (_) { false; };
         };
     };
 
     public let hash = func (player : MPublic.Player) : Hash.Hash {
         switch (player) {
-            case (#stoic(player)) { Text.hash(player); };
-            case (#plug(player))  { Text.hash(player); };
+            case (#stoic(player)) { Principal.hash(player); };
+            case (#plug(player))  { Principal.hash(player); };
         };
     };
 
     public let toText = func (player : MPublic.Player) : Text {
         switch (player) {
-            case (#stoic(player)) { player; };
-            case (#plug(player))  { player; };
+            case (#stoic(player)) { Principal.toText(player); };
+            case (#plug(player))  { Principal.toText(player); };
         };
     };
 };

--- a/src/Metascore.mo
+++ b/src/Metascore.mo
@@ -32,8 +32,8 @@ module {
     // Represents a player.
     // Supported: Stoic and Plug.
     public type Player = {
-        #stoic : Text;
-        #plug  : Text;
+        #stoic : Principal;
+        #plug  : Principal;
     };
 
     // Score of a player.


### PR DESCRIPTION
Norton was advocating using `Principal` instead of `Text` for our `Player` type. He pointed out both Stoic and Plug give us a `Principal`. I originally used `Text` because it was my understanding the Stoic allowed IC Ledger style addresses as well as Principals. Both wallets are at least capable of generating a principal, so we should standardize in that direction.